### PR TITLE
Treat `Condition`s with empty array values as empty string values

### DIFF
--- a/aws_policy_equivalence.go
+++ b/aws_policy_equivalence.go
@@ -403,6 +403,9 @@ func newStringSet(members interface{}) stringSet {
 				return nil
 			}
 		}
+		if len(actions) == 0 {
+			return stringSet{}
+		}
 		return stringSet(actions)
 	default:
 		return nil

--- a/aws_policy_equivalence_test.go
+++ b/aws_policy_equivalence_test.go
@@ -279,6 +279,12 @@ func TestPolicyEquivalence(t *testing.T) {
 			policy2:    policyTest37b,
 			equivalent: true,
 		},
+		{
+			name:       "Condition containing empty array",
+			policy1:    policyTest38a,
+			policy2:    policyTest38b,
+			equivalent: true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -1483,6 +1489,44 @@ const policyTest37b = `{
     }
   ]
  }`
+
+const policyTest38a = `{
+  "Id":"sqspolicy",
+  "Statement":[
+     {
+        "Action":"sqs:SendMessage",
+        "Condition":{
+           "ArnEquals":{
+              "aws:SourceArn":[]
+           }
+        },
+        "Effect":"Allow",
+        "Principal":"*",
+        "Resource":"arn:aws:sqs:***:redacted:redacted",
+        "Sid":"AllowSNSSubscriptions"
+     }
+  ],
+  "Version":"2012-10-17"
+}`
+
+const policyTest38b = `{
+  "Version":"2012-10-17",
+  "Id":"sqspolicy",
+  "Statement":[
+     {
+        "Sid":"AllowSNSSubscriptions",
+        "Effect":"Allow",
+        "Principal":"*",
+        "Action":"sqs:SendMessage",
+        "Resource":"arn:aws:sqs:***:redacted:redacted",
+        "Condition":{
+           "ArnEquals":{
+              "aws:SourceArn":[]
+           }
+        }
+     }
+  ]
+}`
 
 func TestStringValueSlicesEqualIgnoreOrder(t *testing.T) {
 	equal := []interface{}{


### PR DESCRIPTION
Relates: https://github.com/hashicorp/terraform-provider-aws/issues/22505.

Without the fix:

```console
% go test -v .
=== RUN   TestPolicyEquivalence
    aws_policy_equivalence_test.go:300: Bad: Condition containing empty array
          Expected: true
               Got: false
--- FAIL: TestPolicyEquivalence (0.00s)
=== RUN   TestStringValueSlicesEqualIgnoreOrder
--- PASS: TestStringValueSlicesEqualIgnoreOrder (0.00s)
FAIL
FAIL	github.com/hashicorp/awspolicyequivalence	0.924s
FAIL
```