### PR TITLE
Focus more on equivalence, less on policy validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## AWS Policy Equivalence Package
 
-This package checks for structural equivalence of two AWS policy documents. See Godoc for more information on usage.
+This package checks for structural equivalence of two AWS policy documents. See [Godoc](github.com/hashicorp/awspolicyequivalence) for more information on usage.
 
 ### Post v1.5 Validation vs. Equivalence
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-## AWS Policy Equivalence Library
+## AWS Policy Equivalence Package
 
-This library checks for structural equivalence of two AWS policy documents. See Godoc for more information on usage.
+This package checks for structural equivalence of two AWS policy documents. See Godoc for more information on usage.
+
+### Post v1.5 Validation vs. Equivalence
+
+**NOTE:** This package has had a validation role in versions 1.5 and earlier. For example, `{}` is a valid JSON but an invalid AWS policy even though AWS emits it in some cases. Should it be equivalent to itself or throw an error and _not_ be equivalent? Since the purpose of this package is equivalence and not validation, we are removing some of that validation role.
+
+In other words, for v1.5 and earlier, `{}` is not equivalent to itself and returns an error. Post v1.5, `{} is equivalent to itself and _does not_ return an error.
 
 ### CI
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## AWS Policy Equivalence Package
 
-This package checks for structural equivalence of two AWS policy documents. See [Godoc](github.com/hashicorp/awspolicyequivalence) for more information on usage.
+This package checks for structural equivalence of two AWS policy documents. See [Godoc](https://pkg.go.dev/github.com/hashicorp/awspolicyequivalence) for more information on usage.
 
 ### Post v1.5 Validation vs. Equivalence
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This package checks for structural equivalence of two AWS policy documents. See 
 
 ### Post v1.5 Validation vs. Equivalence
 
-**NOTE:** This package has had a validation role in versions 1.5 and earlier. For example, `{}` is a valid JSON but an invalid AWS policy even though AWS emits it in some cases. Should it be equivalent to itself or throw an error and _not_ be equivalent? Since the purpose of this package is equivalence and not validation, we are removing some of that validation role.
+In versions 1.5 and earlier, this package has had a validation role. For example, `{}` is a valid JSON but an invalid AWS policy. But, AWS emits this empty JSON in some cases. Should this package determine `{}` is equivalent to itself or throw an error and say it's _not_ equivalent to itself? Since the purpose of this package is primarily _equivalence_ and not validation, we are removing some of the validation role.
 
-In other words, for v1.5 and earlier, `{}` is not equivalent to itself and returns an error. Post v1.5, `{} is equivalent to itself and _does not_ return an error.
+In other words, for v1.5 and earlier, `{}` is not equivalent to itself and returns an error. Post v1.5, `{}` is equivalent to itself and _does not_ return an error. **_This may impact you if you have relied on this package for validation!_**
 
 ### CI
 

--- a/aws_policy_equivalence.go
+++ b/aws_policy_equivalence.go
@@ -37,17 +37,19 @@ func PoliciesAreEquivalent(policy1, policy2 string) (bool, error) {
 	policy1 = strings.TrimSpace(policy1)
 	if strings.HasPrefix(policy1, "[") && strings.HasSuffix(policy1, "]") {
 		policy1 = strings.TrimPrefix(strings.TrimSuffix(policy1, "]"), "[")
-		if strings.TrimSpace(policy1) == "" {
-			policy1 = "{}"
-		}
+		policy1 = strings.TrimSpace(policy1)
+	}
+	if policy1 == "" {
+		policy1 = "{}"
 	}
 
 	policy2 = strings.TrimSpace(policy2)
 	if strings.HasPrefix(policy2, "[") && strings.HasSuffix(policy2, "]") {
 		policy2 = strings.TrimPrefix(strings.TrimSuffix(policy2, "]"), "[")
-		if strings.TrimSpace(policy2) == "" {
-			policy2 = "{}"
-		}
+		policy2 = strings.TrimSpace(policy2)
+	}
+	if policy2 == "" {
+		policy2 = "{}"
 	}
 
 	policy1intermediate := &intermediatePolicyDocument{}

--- a/aws_policy_equivalence.go
+++ b/aws_policy_equivalence.go
@@ -52,12 +52,12 @@ func PoliciesAreEquivalent(policy1, policy2 string) (bool, error) {
 
 	policy1intermediate := &intermediatePolicyDocument{}
 	if err := json.Unmarshal([]byte(policy1), policy1intermediate); err != nil {
-		return false, fmt.Errorf("unmarshaling policy: %s", err)
+		return false, fmt.Errorf("unmarshaling policy 1: %s", err)
 	}
 
 	policy2intermediate := &intermediatePolicyDocument{}
 	if err := json.Unmarshal([]byte(policy2), policy2intermediate); err != nil {
-		return false, fmt.Errorf("unmarshaling policy: %s", err)
+		return false, fmt.Errorf("unmarshaling policy 2: %s", err)
 	}
 
 	if reflect.DeepEqual(policy1intermediate, policy2intermediate) {
@@ -88,12 +88,12 @@ func (intermediate *intermediatePolicyDocument) document() (*policyDocument, err
 	switch s := intermediate.Statements.(type) {
 	case []interface{}:
 		if err := mapstructure.Decode(s, &statements); err != nil {
-			return nil, fmt.Errorf("parsing statement: %s", err)
+			return nil, fmt.Errorf("parsing statement 1: %s", err)
 		}
 	case map[string]interface{}:
 		var singleStatement *policyStatement
 		if err := mapstructure.Decode(s, &singleStatement); err != nil {
-			return nil, fmt.Errorf("parsing statement: %s", err)
+			return nil, fmt.Errorf("parsing statement 2: %s", err)
 		}
 		statements = append(statements, singleStatement)
 	default:

--- a/aws_policy_equivalence.go
+++ b/aws_policy_equivalence.go
@@ -31,7 +31,7 @@ import (
 // otherwise. If either of the input strings are not valid JSON,
 // false is returned along with an error.
 func PoliciesAreEquivalent(policy1, policy2 string) (bool, error) {
-	// Although "policy" generally equates to JSON, AWS also has psuedo-JSON
+	// Although "policy" generally equates to JSON, AWS also has pseudo-JSON
 	// policies, such as assume-role policies that can be lists of JSONs. This
 	// only handles a one-length list of JSON:
 	policy1 = strings.TrimSpace(policy1)

--- a/aws_policy_equivalence.go
+++ b/aws_policy_equivalence.go
@@ -31,23 +31,46 @@ import (
 // otherwise. If either of the input strings are not valid JSON,
 // false is returned along with an error.
 func PoliciesAreEquivalent(policy1, policy2 string) (bool, error) {
+	// Although "policy" generally equates to JSON, AWS also has psuedo-JSON
+	// policies, such as assume-role policies that can be lists of JSONs. This
+	// only handles a one-length list of JSON:
+	policy1 = strings.TrimSpace(policy1)
+	if strings.HasPrefix(strings.TrimSpace(policy1), "[") {
+		policy1 = strings.TrimPrefix(strings.TrimSuffix(policy1, "]"), "[")
+		if strings.TrimSpace(policy1) == "" {
+			policy1 = "{}"
+		}
+	}
+
+	policy2 = strings.TrimSpace(policy2)
+	if strings.HasPrefix(strings.TrimSpace(policy2), "[") {
+		policy2 = strings.TrimPrefix(strings.TrimSuffix(policy2, "]"), "[")
+		if strings.TrimSpace(policy2) == "" {
+			policy2 = "{}"
+		}
+	}
+
 	policy1intermediate := &intermediatePolicyDocument{}
 	if err := json.Unmarshal([]byte(policy1), policy1intermediate); err != nil {
-		return false, fmt.Errorf("Error unmarshaling policy: %s", err)
+		return false, fmt.Errorf("unmarshaling policy: %s", err)
 	}
 
 	policy2intermediate := &intermediatePolicyDocument{}
 	if err := json.Unmarshal([]byte(policy2), policy2intermediate); err != nil {
-		return false, fmt.Errorf("Error unmarshaling policy: %s", err)
+		return false, fmt.Errorf("unmarshaling policy: %s", err)
+	}
+
+	if reflect.DeepEqual(policy1intermediate, policy2intermediate) {
+		return true, nil
 	}
 
 	policy1Doc, err := policy1intermediate.document()
 	if err != nil {
-		return false, fmt.Errorf("Error parsing policy: %s", err)
+		return false, fmt.Errorf("parsing policy 1: %s", err)
 	}
 	policy2Doc, err := policy2intermediate.document()
 	if err != nil {
-		return false, fmt.Errorf("Error parsing policy: %s", err)
+		return false, fmt.Errorf("parsing policy 2: %s", err)
 	}
 
 	return policy1Doc.equals(policy2Doc), nil
@@ -65,12 +88,12 @@ func (intermediate *intermediatePolicyDocument) document() (*policyDocument, err
 	switch s := intermediate.Statements.(type) {
 	case []interface{}:
 		if err := mapstructure.Decode(s, &statements); err != nil {
-			return nil, fmt.Errorf("Error parsing statement: %s", err)
+			return nil, fmt.Errorf("parsing statement: %s", err)
 		}
 	case map[string]interface{}:
 		var singleStatement *policyStatement
 		if err := mapstructure.Decode(s, &singleStatement); err != nil {
-			return nil, fmt.Errorf("Error parsing statement: %s", err)
+			return nil, fmt.Errorf("parsing statement: %s", err)
 		}
 		statements = append(statements, singleStatement)
 	default:

--- a/aws_policy_equivalence.go
+++ b/aws_policy_equivalence.go
@@ -35,7 +35,7 @@ func PoliciesAreEquivalent(policy1, policy2 string) (bool, error) {
 	// policies, such as assume-role policies that can be lists of JSONs. This
 	// only handles a one-length list of JSON:
 	policy1 = strings.TrimSpace(policy1)
-	if strings.HasPrefix(policy1, "[") {
+	if strings.HasPrefix(policy1, "[") && strings.HasSuffix(policy1, "]") {
 		policy1 = strings.TrimPrefix(strings.TrimSuffix(policy1, "]"), "[")
 		if strings.TrimSpace(policy1) == "" {
 			policy1 = "{}"
@@ -43,7 +43,7 @@ func PoliciesAreEquivalent(policy1, policy2 string) (bool, error) {
 	}
 
 	policy2 = strings.TrimSpace(policy2)
-	if strings.HasPrefix(policy2, "[") {
+	if strings.HasPrefix(policy2, "[") && strings.HasSuffix(policy2, "]") {
 		policy2 = strings.TrimPrefix(strings.TrimSuffix(policy2, "]"), "[")
 		if strings.TrimSpace(policy2) == "" {
 			policy2 = "{}"

--- a/aws_policy_equivalence.go
+++ b/aws_policy_equivalence.go
@@ -35,7 +35,7 @@ func PoliciesAreEquivalent(policy1, policy2 string) (bool, error) {
 	// policies, such as assume-role policies that can be lists of JSONs. This
 	// only handles a one-length list of JSON:
 	policy1 = strings.TrimSpace(policy1)
-	if strings.HasPrefix(strings.TrimSpace(policy1), "[") {
+	if strings.HasPrefix(policy1, "[") {
 		policy1 = strings.TrimPrefix(strings.TrimSuffix(policy1, "]"), "[")
 		if strings.TrimSpace(policy1) == "" {
 			policy1 = "{}"
@@ -43,7 +43,7 @@ func PoliciesAreEquivalent(policy1, policy2 string) (bool, error) {
 	}
 
 	policy2 = strings.TrimSpace(policy2)
-	if strings.HasPrefix(strings.TrimSpace(policy2), "[") {
+	if strings.HasPrefix(policy2, "[") {
 		policy2 = strings.TrimPrefix(strings.TrimSuffix(policy2, "]"), "[")
 		if strings.TrimSpace(policy2) == "" {
 			policy2 = "{}"

--- a/aws_policy_equivalence_test.go
+++ b/aws_policy_equivalence_test.go
@@ -227,15 +227,15 @@ func TestPolicyEquivalence(t *testing.T) {
 			name:       "Missing Statement",
 			policy1:    policyTest30,
 			policy2:    policyTest30,
-			equivalent: false,
-			err:        true,
+			equivalent: true,
+			err:        false,
 		},
 		{
 			name:       "Incorrect Statement type",
 			policy1:    policyTest31,
 			policy2:    policyTest31,
-			equivalent: false,
-			err:        true,
+			equivalent: true,
+			err:        false,
 		},
 		{
 			name:       "Incorrect single Resource type",
@@ -283,6 +283,18 @@ func TestPolicyEquivalence(t *testing.T) {
 			name:       "Condition containing empty array",
 			policy1:    policyTest38a,
 			policy2:    policyTest38b,
+			equivalent: true,
+		},
+		{
+			name:       "Different empty lists",
+			policy1:    policyTest39a,
+			policy2:    policyTest39b,
+			equivalent: true,
+		},
+		{
+			name:       "One-length lists",
+			policy1:    policyTest40a,
+			policy2:    policyTest40b,
 			equivalent: true,
 		},
 	}
@@ -1525,6 +1537,38 @@ const policyTest38b = `{
            }
         }
      }
+  ]
+}`
+
+const policyTest39a = `[]`
+
+const policyTest39b = `[{
+
+}]`
+
+const policyTest40a = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "statement1",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": [42, 86]
+    }
+  ]
+}`
+
+const policyTest40b = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "statement1",
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+      "Resource": [86, 42]
+    }
   ]
 }`
 

--- a/aws_policy_equivalence_test.go
+++ b/aws_policy_equivalence_test.go
@@ -297,6 +297,24 @@ func TestPolicyEquivalence(t *testing.T) {
 			policy2:    policyTest40b,
 			equivalent: true,
 		},
+		{
+			name:       "Equivalent assume-role policies 1",
+			policy1:    policyTest41a,
+			policy2:    policyTest41b,
+			equivalent: true,
+		},
+		{
+			name:       "Equivalent assume-role policies 2",
+			policy1:    policyTest42a,
+			policy2:    policyTest42b,
+			equivalent: true,
+		},
+		{
+			name:       "Not equivalent assume-role policies",
+			policy1:    policyTest43a,
+			policy2:    policyTest43b,
+			equivalent: false,
+		},
 	}
 
 	for _, tc := range cases {
@@ -1571,6 +1589,15 @@ const policyTest40b = `{
     }
   ]
 }`
+
+const policyTest41a = `{"Statement":[{"Action":"sts:AssumeRole","Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"}}],"Version":"2012-10-17"}`
+const policyTest41b = `{"Statement":[{"Action":["sts:AssumeRole"],"Effect":"Allow","Principal":{"Service":["ec2.amazonaws.com"]}}],"Version":"2012-10-17"}`
+
+const policyTest42a = `{"Statement":[{"Action":"sts:AssumeRole","Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"}}],"Version":"2012-10-17"}`
+const policyTest42b = `{"Statement":[{"Action":"sts:AssumeRole","Effect":"Allow","Principal":{"Service":["ec2.amazonaws.com"]}}],"Version":"2012-10-17"}`
+
+const policyTest43a = `{"Statement":[{"Action":"sts:AssumeRole","Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"}}],"Version":"2012-10-17"}`
+const policyTest43b = `{"Statement":[{"Action":"sts:AssumeRole","Effect":"Allow","Principal":{"Service":["rds.amazonaws.com"]}}],"Version":"2012-10-17"}`
 
 func TestStringValueSlicesEqualIgnoreOrder(t *testing.T) {
 	equal := []interface{}{

--- a/aws_policy_equivalence_test.go
+++ b/aws_policy_equivalence_test.go
@@ -315,6 +315,12 @@ func TestPolicyEquivalence(t *testing.T) {
 			policy2:    policyTest43b,
 			equivalent: false,
 		},
+		{
+			name:       "Equivalence of emptiness",
+			policy1:    policyTest44a,
+			policy2:    policyTest44b,
+			equivalent: true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -1598,6 +1604,9 @@ const policyTest42b = `{"Statement":[{"Action":"sts:AssumeRole","Effect":"Allow"
 
 const policyTest43a = `{"Statement":[{"Action":"sts:AssumeRole","Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"}}],"Version":"2012-10-17"}`
 const policyTest43b = `{"Statement":[{"Action":"sts:AssumeRole","Effect":"Allow","Principal":{"Service":["rds.amazonaws.com"]}}],"Version":"2012-10-17"}`
+
+const policyTest44a = ``
+const policyTest44b = `{}`
 
 func TestStringValueSlicesEqualIgnoreOrder(t *testing.T) {
 	equal := []interface{}{


### PR DESCRIPTION
In a nutshell, this aligns the philosophy of checking equivalence with what we are actually doing. Before, we had some validation tendencies. Not a valid AWS policy? Not equivalent to itself and return an error. Here, if we can determine equivalence, regardless of validity, we do so.

This is important because AWS returns some things that are not valid JSON or AWS policies. However, we should be able to handle anything AWS gives us so that we don't have to have additional check layers on top of this package.

```
% go test ./...                               
ok  	github.com/hashicorp/awspolicyequivalence	0.730s
```